### PR TITLE
Change syntax to support es6 module support

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -1,0 +1,7 @@
+* **[Michael Raymond](https://github.com/mraymond)**
+
+  * Project Architect
+
+* **[Frank Tran](https://github.com/sowhatdoido)**
+
+  * Added ES6 Module support

--- a/neumatico.js
+++ b/neumatico.js
@@ -1,3 +1,5 @@
-setInterval(function() {
+export default function(){
+  setInterval(function() {
     document.documentElement.style.cssText = "height:100%;width:100%;overflow:auto;transform: rotate("+Date.now()%360+"deg);";
-},10);
+  },10);
+}


### PR DESCRIPTION
Adding the es6 export syntax allows Neumatico to be used with module bundlers, as well as modern browsers via the `type="module"` property.